### PR TITLE
Package collection JWS signing (SwiftPM-compatible)

### DIFF
--- a/collectionsign/from_config.go
+++ b/collectionsign/from_config.go
@@ -1,0 +1,28 @@
+package collectionsign
+
+import (
+	"errors"
+	"fmt"
+
+	"OpenSPMRegistry/config"
+)
+
+// LoadSignerForPackageCollections returns a Signer when package collections and signing are enabled in config.
+// It returns (nil, nil) when signing is disabled. It returns an error if signing is enabled but misconfigured
+// or if loading keys/certs fails.
+func LoadSignerForPackageCollections(pc config.PackageCollectionsConfig) (*Signer, error) {
+	if !pc.Signing.Enabled {
+		return nil, nil
+	}
+	if !pc.Enabled {
+		return nil, errors.New("packageCollections.signing.enabled requires packageCollections.enabled")
+	}
+	if len(pc.Signing.CertChain) == 0 || pc.Signing.PrivateKey == "" {
+		return nil, errors.New("packageCollections.signing.enabled requires certChain (non-empty) and privateKey")
+	}
+	s, err := NewSignerFromFiles(pc.Signing.CertChain, pc.Signing.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("package collection signing: %w", err)
+	}
+	return s, nil
+}

--- a/collectionsign/from_config_test.go
+++ b/collectionsign/from_config_test.go
@@ -1,0 +1,42 @@
+package collectionsign
+
+import (
+	"testing"
+
+	"OpenSPMRegistry/config"
+)
+
+func TestLoadSignerForPackageCollections_Disabled(t *testing.T) {
+	s, err := LoadSignerForPackageCollections(config.PackageCollectionsConfig{
+		Enabled: true,
+		Signing: config.PackageCollectionsSigningConfig{Enabled: false},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != nil {
+		t.Fatal("expected nil signer")
+	}
+}
+
+func TestLoadSignerForPackageCollections_SigningWithoutCollections(t *testing.T) {
+	_, err := LoadSignerForPackageCollections(config.PackageCollectionsConfig{
+		Enabled: false,
+		Signing: config.PackageCollectionsSigningConfig{Enabled: true},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadSignerForPackageCollections_MissingPaths(t *testing.T) {
+	_, err := LoadSignerForPackageCollections(config.PackageCollectionsConfig{
+		Enabled: true,
+		Signing: config.PackageCollectionsSigningConfig{
+			Enabled: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/collectionsign/sign.go
+++ b/collectionsign/sign.go
@@ -1,0 +1,235 @@
+// Package collectionsign produces SwiftPM-compatible signed package collections
+// (JWS over the collection JSON plus root-level signature metadata), matching
+// PackageCollectionsSigning in swift-package-manager.
+package collectionsign
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+
+	"OpenSPMRegistry/models"
+)
+
+// Signer signs package collections using a certificate chain and private key.
+type Signer struct {
+	certChain [][]byte
+	leaf      *x509.Certificate
+	key       crypto.Signer
+	alg       string // ES256 or RS256
+}
+
+type jwsHeader struct {
+	Algorithm string   `json:"alg"`
+	CertChain []string `json:"x5c"`
+}
+
+// signedCollectionSignature is the JSON object under the root "signature" key (Swift PackageCollectionModel.V1.Signature).
+type signedCollectionSignature struct {
+	Signature   string        `json:"signature"`
+	Certificate signatureCert `json:"certificate"`
+}
+
+type signatureCert struct {
+	Subject certName `json:"subject"`
+	Issuer  certName `json:"issuer"`
+}
+
+type certName struct {
+	UserID             *string `json:"userID,omitempty"`
+	CommonName         *string `json:"commonName,omitempty"`
+	OrganizationalUnit *string `json:"organizationalUnit,omitempty"`
+	Organization       *string `json:"organization,omitempty"`
+}
+
+const minRSABits = 2048
+
+// NewSignerFromFiles loads DER certificates (leaf first, then intermediates) and a PEM private key.
+func NewSignerFromFiles(certChainPaths []string, privateKeyPath string) (*Signer, error) {
+	if len(certChainPaths) == 0 {
+		return nil, errors.New("collection signing: empty certificate chain")
+	}
+	chain := make([][]byte, 0, len(certChainPaths))
+	for _, p := range certChainPaths {
+		der, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("collection signing: read cert %q: %w", p, err)
+		}
+		chain = append(chain, der)
+	}
+	leaf, err := x509.ParseCertificate(chain[0])
+	if err != nil {
+		return nil, fmt.Errorf("collection signing: parse leaf certificate: %w", err)
+	}
+	keyPEM, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("collection signing: read private key %q: %w", privateKeyPath, err)
+	}
+	key, err := parsePrivateKeyPEM(keyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	var alg string
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		if k.Curve.Params().Name != "P-256" {
+			return nil, errors.New("collection signing: only P-256 (ES256) ECDSA keys are supported")
+		}
+		alg = "ES256"
+	case *rsa.PrivateKey:
+		if k.N.BitLen() < minRSABits {
+			return nil, fmt.Errorf("collection signing: RSA key must be at least %d bits", minRSABits)
+		}
+		alg = "RS256"
+	default:
+		return nil, errors.New("collection signing: unsupported private key type")
+	}
+
+	return &Signer{
+		certChain: chain,
+		leaf:      leaf,
+		key:       key,
+		alg:       alg,
+	}, nil
+}
+
+func parsePrivateKeyPEM(pemData []byte) (crypto.Signer, error) {
+	var block *pem.Block
+	for {
+		block, pemData = pem.Decode(pemData)
+		if block == nil {
+			return nil, errors.New("collection signing: no PEM block in private key file")
+		}
+		if block.Type == "EC PRIVATE KEY" || block.Type == "RSA PRIVATE KEY" || block.Type == "PRIVATE KEY" {
+			break
+		}
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		if s, ok := key.(crypto.Signer); ok {
+			return s, nil
+		}
+		return nil, errors.New("collection signing: PKCS#8 key is not a signer")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	return nil, errors.New("collection signing: could not parse private key PEM")
+}
+
+// WrapSignedCollection returns JSON bytes: all collection fields plus "signature", compatible with SwiftPM SignedCollection.
+func (s *Signer) WrapSignedCollection(coll *models.PackageCollection) ([]byte, error) {
+	payload, err := json.Marshal(coll)
+	if err != nil {
+		return nil, fmt.Errorf("collection signing: marshal collection: %w", err)
+	}
+
+	x5c := make([]string, len(s.certChain))
+	for i, der := range s.certChain {
+		x5c[i] = base64.StdEncoding.EncodeToString(der)
+	}
+	header := jwsHeader{Algorithm: s.alg, CertChain: x5c}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return nil, fmt.Errorf("collection signing: marshal JWS header: %w", err)
+	}
+
+	encHeader := base64.RawURLEncoding.EncodeToString(headerJSON)
+	encPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := encHeader + "." + encPayload
+
+	sum := sha256.Sum256([]byte(signingInput))
+	sigBytes, err := signDigest(s.key, s.alg, sum[:])
+	if err != nil {
+		return nil, err
+	}
+	encSig := base64.RawURLEncoding.EncodeToString(sigBytes)
+	jws := encHeader + "." + encPayload + "." + encSig
+
+	sigObj := signedCollectionSignature{
+		Signature: jws,
+		Certificate: signatureCert{
+			Subject: certNameFromPKIX(s.leaf.Subject),
+			Issuer:  certNameFromPKIX(s.leaf.Issuer),
+		},
+	}
+
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return nil, fmt.Errorf("collection signing: payload to map: %w", err)
+	}
+	sigField, err := json.Marshal(sigObj)
+	if err != nil {
+		return nil, fmt.Errorf("collection signing: marshal signature object: %w", err)
+	}
+	root["signature"] = sigField
+	out, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("collection signing: marshal signed collection: %w", err)
+	}
+	return out, nil
+}
+
+func certNameFromPKIX(n pkix.Name) certName {
+	out := certName{}
+	if n.CommonName != "" {
+		s := n.CommonName
+		out.CommonName = &s
+	}
+	if len(n.Organization) > 0 {
+		s := n.Organization[0]
+		out.Organization = &s
+	}
+	if len(n.OrganizationalUnit) > 0 {
+		s := n.OrganizationalUnit[0]
+		out.OrganizationalUnit = &s
+	}
+	return out
+}
+
+func signDigest(key crypto.Signer, alg string, digest []byte) ([]byte, error) {
+	switch alg {
+	case "ES256":
+		ec, ok := key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("collection signing: internal error: ES256 without ECDSA key")
+		}
+		r, s, err := ecdsa.Sign(rand.Reader, ec, digest)
+		if err != nil {
+			return nil, fmt.Errorf("collection signing: ECDSA sign: %w", err)
+		}
+		return encodeECDSAP256Raw(r, s), nil
+	case "RS256":
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("collection signing: internal error: RS256 without RSA key")
+		}
+		return rsa.SignPKCS1v15(rand.Reader, rsaKey, crypto.SHA256, digest)
+	default:
+		return nil, fmt.Errorf("collection signing: unknown algorithm %q", alg)
+	}
+}
+
+// encodeECDSAP256Raw returns R||S as 32-byte big-endian integers (Swift Crypto P256.Signature rawRepresentation).
+func encodeECDSAP256Raw(r, s *big.Int) []byte {
+	rb := r.Bytes()
+	sb := s.Bytes()
+	out := make([]byte, 64)
+	copy(out[32-len(rb):32], rb)
+	copy(out[64-len(sb):], sb)
+	return out
+}

--- a/collectionsign/sign_test.go
+++ b/collectionsign/sign_test.go
@@ -1,0 +1,207 @@
+package collectionsign
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"OpenSPMRegistry/models"
+)
+
+func TestNewSignerFromFiles_ECDSA(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeTestP256Chain(t, dir)
+
+	s, err := NewSignerFromFiles([]string{certPath}, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.alg != "ES256" {
+		t.Fatalf("alg: got %q", s.alg)
+	}
+}
+
+func TestNewSignerFromFiles_Errors(t *testing.T) {
+	if _, err := NewSignerFromFiles(nil, "k.pem"); err == nil {
+		t.Fatal("expected error for empty chain")
+	}
+	dir := t.TempDir()
+	if _, err := NewSignerFromFiles([]string{filepath.Join(dir, "missing.der")}, "k.pem"); err == nil {
+		t.Fatal("expected error for missing cert")
+	}
+}
+
+func TestWrapSignedCollection_VerifyJWS(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeTestP256Chain(t, dir)
+	s, err := NewSignerFromFiles([]string{certPath}, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	coll := &models.PackageCollection{
+		Name:          "Test",
+		Overview:      "Overview",
+		FormatVersion: "1.0",
+		Revision:      1,
+		GeneratedAt:   "2025-01-01T00:00:00Z",
+		GeneratedBy:   models.GeneratedBy{Name: "OpenSPMRegistry"},
+		Packages: []models.CollectionPackage{
+			{
+				URL: "scope.pkg",
+				Versions: []models.PackageVersion{
+					{
+						Version:             "1.0.0",
+						DefaultToolsVersion: "5.10",
+						Manifests: map[string]models.PackageManifest{
+							"5.10": {
+								ToolsVersion: "5.10",
+								PackageName:  "pkg",
+								Targets:      []models.Target{{Name: "T"}},
+								Products:     []models.Product{{Name: "P", Targets: []string{"T"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	signed, err := s.WrapSignedCollection(coll)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(signed, &root); err != nil {
+		t.Fatal(err)
+	}
+	sigRaw, ok := root["signature"]
+	if !ok {
+		t.Fatal("missing signature key")
+	}
+	var sigObj signedCollectionSignature
+	if err := json.Unmarshal(sigRaw, &sigObj); err != nil {
+		t.Fatal(err)
+	}
+	parts := splitJWS(sigObj.Signature)
+	if len(parts) != 3 {
+		t.Fatalf("JWS parts: got %d", len(parts))
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hdr jwsHeader
+	if err := json.Unmarshal(headerJSON, &hdr); err != nil {
+		t.Fatal(err)
+	}
+	if hdr.Algorithm != "ES256" {
+		t.Fatalf("header alg: %q", hdr.Algorithm)
+	}
+	if len(hdr.CertChain) < 1 {
+		t.Fatal("empty x5c")
+	}
+	certDER, err := base64.StdEncoding.DecodeString(hdr.CertChain[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, ok := leaf.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("expected ECDSA public key")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var inner models.PackageCollection
+	if err := json.Unmarshal(payload, &inner); err != nil {
+		t.Fatal(err)
+	}
+	if inner.Name != coll.Name || len(inner.Packages) != len(coll.Packages) {
+		t.Fatal("inner payload collection mismatch")
+	}
+
+	msg := parts[0] + "." + parts[1]
+	digest := sha256.Sum256([]byte(msg))
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sigBytes) != 64 {
+		t.Fatalf("ECDSA raw sig len %d", len(sigBytes))
+	}
+	r := new(big.Int).SetBytes(sigBytes[:32])
+	sBig := new(big.Int).SetBytes(sigBytes[32:])
+	if !ecdsa.Verify(pub, digest[:], r, sBig) {
+		t.Fatal("ECDSA verify failed")
+	}
+}
+
+func splitJWS(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+func writeTestP256Chain(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:         "collection-signer",
+			Organization:       []string{"Test Org"},
+			OrganizationalUnit: []string{"Test OU"},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath = filepath.Join(dir, "leaf.der")
+	if err := os.WriteFile(certPath, der, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pk8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBuf := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pk8})
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(keyPath, pemBuf, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}

--- a/config.yml
+++ b/config.yml
@@ -21,3 +21,8 @@ server:
   packageCollections:
     enabled: true
     requirePackageJson: false
+    # Optional SwiftPM signed collections (JWS); leaf DER first, then intermediates.
+    # signing:
+    #   enabled: true
+    #   certChain: ["./certs/collection-leaf.der", "./certs/collection-ca.der"]
+    #   privateKey: "./certs/collection-key.pem"

--- a/config/server.go
+++ b/config/server.go
@@ -69,6 +69,15 @@ type PackageCollectionsConfig struct {
 	// that cannot send headers (e.g. swift package-collection add). Off by default to avoid credential
 	// leakage via logs, referrers, and proxies. When true, decoded value must start with "Basic " or "Bearer ".
 	AllowAuthQueryParam bool `yaml:"allowAuthQueryParam"`
+	// Signing produces SwiftPM-compatible signed collections (JWS + certificate metadata).
+	Signing PackageCollectionsSigningConfig `yaml:"signing"`
+}
+
+// PackageCollectionsSigningConfig enables JWS signing of package collection JSON (swift-package-manager PackageCollectionsSigning).
+type PackageCollectionsSigningConfig struct {
+	Enabled    bool     `yaml:"enabled"`
+	CertChain  []string `yaml:"certChain"`  // DER files, leaf certificate first
+	PrivateKey string   `yaml:"privateKey"` // PEM private key (PKCS#8, PKCS#1, or EC)
 }
 
 const (

--- a/controller/collections.go
+++ b/controller/collections.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"OpenSPMRegistry/mimetypes"
+	"OpenSPMRegistry/models"
 	"OpenSPMRegistry/repo"
 	"encoding/json"
 	"log/slog"
@@ -36,23 +37,7 @@ func (c *Controller) GlobalCollectionAction(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Set headers
-	data, err := json.Marshal(collection)
-	if err != nil {
-		slog.Error("Error marshaling collection JSON", "error", err)
-		writeErrorWithStatusCode("Error generating collection", w, http.StatusInternalServerError)
-		return
-	}
-
-	header := w.Header()
-	header.Set("Content-Type", mimetypes.ApplicationJson)
-	header.Set("Content-Length", strconv.Itoa(len(data)))
-
-	// Return collection as JSON
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(data); err != nil {
-		slog.Error("Error writing collection JSON", "error", err)
-	}
+	c.writeCollectionResponse(w, collection)
 }
 
 // ScopeCollectionAction handles GET /collection/{scope} requests for scope-specific collections
@@ -94,8 +79,17 @@ func (c *Controller) ScopeCollectionAction(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Set headers
-	data, err := json.Marshal(collection)
+	c.writeCollectionResponse(w, collection)
+}
+
+func (c *Controller) writeCollectionResponse(w http.ResponseWriter, collection *models.PackageCollection) {
+	var data []byte
+	var err error
+	if c.collectionSigner != nil {
+		data, err = c.collectionSigner.WrapSignedCollection(collection)
+	} else {
+		data, err = json.Marshal(collection)
+	}
 	if err != nil {
 		slog.Error("Error marshaling collection JSON", "error", err)
 		writeErrorWithStatusCode("Error generating collection", w, http.StatusInternalServerError)
@@ -105,8 +99,6 @@ func (c *Controller) ScopeCollectionAction(w http.ResponseWriter, r *http.Reques
 	header := w.Header()
 	header.Set("Content-Type", mimetypes.ApplicationJson)
 	header.Set("Content-Length", strconv.Itoa(len(data)))
-
-	// Return collection as JSON
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(data); err != nil {
 		slog.Error("Error writing collection JSON", "error", err)

--- a/controller/collections_test.go
+++ b/controller/collections_test.go
@@ -2,13 +2,23 @@ package controller
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"OpenSPMRegistry/collectionsign"
 	"OpenSPMRegistry/config"
 	"OpenSPMRegistry/models"
 	"OpenSPMRegistry/responses"
@@ -46,6 +56,45 @@ func Test_GlobalCollectionAction_CollectionsDisabled_ReturnsNotFound(t *testing.
 	}
 	if resp.Detail != "Package collections are not enabled" {
 		t.Fatalf("unexpected error detail: %s", resp.Detail)
+	}
+}
+
+func Test_GlobalCollectionAction_WithCollectionSigner_ReturnsSignedJSON(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeTestP256CertForCollection(t, dir)
+	signer, err := collectionsign.NewSignerFromFiles([]string{certPath}, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := newCollectionTestRepo([]models.ListElement{
+		{Scope: "scope", PackageName: "pkg", Version: "1.0.0"},
+	})
+	c := NewController(
+		config.ServerConfig{
+			Hostname:           "example.com",
+			PackageCollections: config.PackageCollectionsConfig{Enabled: true},
+		},
+		repo,
+		WithCollectionSigner(signer),
+	)
+
+	req := httptest.NewRequest("GET", "/collection", nil)
+	w := httptest.NewRecorder()
+	c.GlobalCollectionAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &root); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, ok := root["signature"]; !ok {
+		t.Fatal("expected signed collection to include signature key")
+	}
+	if _, ok := root["packages"]; !ok {
+		t.Fatal("expected packages key")
 	}
 }
 
@@ -289,4 +338,37 @@ func (r *collectionTestRepo) GetSwiftToolVersion(ctx context.Context, manifest *
 
 func (r *collectionTestRepo) PublishDate(ctx context.Context, element *models.UploadElement) (time.Time, error) {
 	return r.publishDate, nil
+}
+
+func writeTestP256CertForCollection(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "collection-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath = filepath.Join(dir, "leaf.der")
+	if err := os.WriteFile(certPath, der, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pk8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pk8}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
 }

--- a/controller/general.go
+++ b/controller/general.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"OpenSPMRegistry/collectionsign"
 	"OpenSPMRegistry/config"
 	"OpenSPMRegistry/repo"
 	"OpenSPMRegistry/utils"
@@ -8,17 +9,32 @@ import (
 )
 
 type Controller struct {
-	config       config.ServerConfig
-	repo         repo.Repo
-	timeProvider utils.TimeProvider
+	config             config.ServerConfig
+	repo               repo.Repo
+	timeProvider       utils.TimeProvider
+	collectionSigner   *collectionsign.Signer
 }
 
-func NewController(config config.ServerConfig, repo repo.Repo) *Controller {
-	return &Controller{
+// ControllerOption configures NewController.
+type ControllerOption func(*Controller)
+
+// WithCollectionSigner enables SwiftPM signed package collections (JWS) on GET /collection responses.
+func WithCollectionSigner(s *collectionsign.Signer) ControllerOption {
+	return func(c *Controller) {
+		c.collectionSigner = s
+	}
+}
+
+func NewController(config config.ServerConfig, repo repo.Repo, opts ...ControllerOption) *Controller {
+	c := &Controller{
 		config:       config,
 		repo:         repo,
 		timeProvider: utils.NewRealTimeProvider(),
 	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
 }
 
 func (c *Controller) MainAction(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -102,16 +102,12 @@ func main() {
 	}
 	a := middleware.NewAuthentication(authenticator.CreateAuthenticator(serverConfig.Server), registryMux)
 
+	signer, err := collectionsign.LoadSignerForPackageCollections(serverConfig.Server.PackageCollections)
+	if err != nil {
+		log.Fatal(err)
+	}
 	var collOpts []controller.ControllerOption
-	pc := serverConfig.Server.PackageCollections
-	if pc.Enabled && pc.Signing.Enabled {
-		if len(pc.Signing.CertChain) == 0 || pc.Signing.PrivateKey == "" {
-			log.Fatal("packageCollections.signing.enabled requires certChain (non-empty) and privateKey")
-		}
-		signer, err := collectionsign.NewSignerFromFiles(pc.Signing.CertChain, pc.Signing.PrivateKey)
-		if err != nil {
-			log.Fatalf("package collection signing: %v", err)
-		}
+	if signer != nil {
 		collOpts = append(collOpts, controller.WithCollectionSigner(signer))
 		slog.Info("Package collection JWS signing enabled")
 	}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"OpenSPMRegistry/authenticator"
+	"OpenSPMRegistry/collectionsign"
 	"OpenSPMRegistry/config"
 	"OpenSPMRegistry/controller"
 	"OpenSPMRegistry/middleware"
@@ -100,7 +101,21 @@ func main() {
 		log.Fatalf("Unsupported repo type: %s", repoConfig.Type)
 	}
 	a := middleware.NewAuthentication(authenticator.CreateAuthenticator(serverConfig.Server), registryMux)
-	c := controller.NewController(serverConfig.Server, r)
+
+	var collOpts []controller.ControllerOption
+	pc := serverConfig.Server.PackageCollections
+	if pc.Enabled && pc.Signing.Enabled {
+		if len(pc.Signing.CertChain) == 0 || pc.Signing.PrivateKey == "" {
+			log.Fatal("packageCollections.signing.enabled requires certChain (non-empty) and privateKey")
+		}
+		signer, err := collectionsign.NewSignerFromFiles(pc.Signing.CertChain, pc.Signing.PrivateKey)
+		if err != nil {
+			log.Fatalf("package collection signing: %v", err)
+		}
+		collOpts = append(collOpts, controller.WithCollectionSigner(signer))
+		slog.Info("Package collection JWS signing enabled")
+	}
+	c := controller.NewController(serverConfig.Server, r, collOpts...)
 
 	// Package Collections on a separate mux so Go 1.22+ ServeMux does not conflict with /{scope}/{package}.
 	// GET also matches HEAD per Go 1.22+ routing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #28](https://github.com/wgr1984/openspmregistry/issues/28): optional **signed package collections** compatible with SwiftPM’s `PackageCollectionsSigning` / `JSONPackageCollectionProvider`.

## Behavior

- **Unsigned (default):** `GET /collection` and `GET /collection/{scope}` return the same JSON as before.
- **Signed:** When `packageCollections.signing.enabled` is true and `certChain` + `privateKey` are set, responses are a SwiftPM **SignedCollection** shape: all collection fields at the root plus a `signature` object containing:
  - `signature`: compact JWS (`base64url(header).base64url(payload).base64url(sig)`), where the payload is the same JSON as the unsigned collection.
  - `certificate`: subject/issuer names for display (from the leaf cert).

Signing matches swift-package-manager: SHA-256 over the signing input, **ES256** (P-256, 64-byte R||S) or **RS256** (PKCS#1 v1.5, ≥2048-bit RSA), `x5c` in the JWS header as standard Base64 DER.

## Configuration

```yaml
server:
  packageCollections:
    enabled: true
    signing:
      enabled: true
      certChain: ["/path/to/leaf.der", "/path/to/intermediate.der"]  # leaf first
      privateKey: "/path/to/key.pem"  # PEM PKCS#8 / PKCS#1 / EC
```

## Implementation notes

- Signer construction and config validation live in `collectionsign.LoadSignerForPackageCollections`; `main` only applies `fatal` on error and passes `controller.WithCollectionSigner` when non-nil.

## Tests

- `collectionsign`: ECDSA round-trip, JWS verification, config loading edge cases.
- `controller`: signed response includes `signature` and `packages`.

## Notes

Clients still need a trusted root / certificate policy to **verify** signatures (same as SwiftPM). `swift package-collection add` without `--trust-unsigned` will validate when the toolchain and trust store are configured accordingly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c5d52f6-bfcc-4d72-98fe-5aa46b28a18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c5d52f6-bfcc-4d72-98fe-5aa46b28a18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

